### PR TITLE
Enable/Disable 15-mailboxes.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,7 @@ class dovecot (
   $lda_mailbox_autocreate        = undef,
   $lda_mailbox_autosubscribe     = undef,
   # 15-mailboxes.conf
-  $enable_mailboxes_conf         = true,
+  $manage_mailboxes         = true,
   # 20-imap.conf
   $imap_listen_port              = '*:143',
   $imaps_listen_port             = '*:993',
@@ -236,7 +236,7 @@ class dovecot (
   file { "${directory}/conf.d/15-lda.conf":
     content => template('dovecot/conf.d/15-lda.conf.erb'),
   }
-  if $enable_mailboxes_conf {
+  if $manage_mailboxes {
     file { "${directory}/conf.d/15-mailboxes.conf":
       content => template('dovecot/conf.d/15-mailboxes.conf.erb'),
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,7 @@ class dovecot (
   $lda_mailbox_autocreate        = undef,
   $lda_mailbox_autosubscribe     = undef,
   # 15-mailboxes.conf
-  $enable_mailboxes              = true,
+  $enable_mailboxes_conf         = true,
   # 20-imap.conf
   $imap_listen_port              = '*:143',
   $imaps_listen_port             = '*:993',
@@ -236,7 +236,7 @@ class dovecot (
   file { "${directory}/conf.d/15-lda.conf":
     content => template('dovecot/conf.d/15-lda.conf.erb'),
   }
-  if $enable_mailboxes {
+  if $enable_mailboxes_conf {
     file { "${directory}/conf.d/15-mailboxes.conf":
       content => template('dovecot/conf.d/15-mailboxes.conf.erb'),
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,6 +77,8 @@ class dovecot (
   $lda_mail_location             = undef,
   $lda_mailbox_autocreate        = undef,
   $lda_mailbox_autosubscribe     = undef,
+  # 15-mailboxes.conf
+  $enable_mailboxes              = true,
   # 20-imap.conf
   $imap_listen_port              = '*:143',
   $imaps_listen_port             = '*:993',
@@ -234,8 +236,10 @@ class dovecot (
   file { "${directory}/conf.d/15-lda.conf":
     content => template('dovecot/conf.d/15-lda.conf.erb'),
   }
-  file { "${directory}/conf.d/15-mailboxes.conf":
-    content => template('dovecot/conf.d/15-mailboxes.conf.erb'),
+  if $enable_mailboxes {
+    file { "${directory}/conf.d/15-mailboxes.conf":
+      content => template('dovecot/conf.d/15-mailboxes.conf.erb'),
+    }
   }
   file { "${directory}/conf.d/20-imap.conf":
     content => template('dovecot/conf.d/20-imap.conf.erb'),


### PR DESCRIPTION
Older version of dovecot prior to 2.1 specifically on CentOS 6 fail when the 15-mailboxes.conf is configured on the system as it doesn't support those options.

This grants the ability to not place that conf on the system.
